### PR TITLE
Migrate example to maven, with gwt maven plugin, and move to current version of gwt 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,13 @@
     <artifactId>gwt-appcache-example</artifactId>
     <version>1.0-SNAPSHOT</version>
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <!-- Convenience property to set the GWT version -->
         <gwtVersion>2.7.0</gwtVersion>
         <gwt.maven.plugin.version>2.7.0</gwt.maven.plugin.version>
         <gwt.style>DETAILED</gwt.style>
-
+        <javaVersion>1.7</javaVersion>
         <!-- GWT needs at least java 1.5 -->
         <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
     </properties>
@@ -94,6 +96,15 @@
     -->
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>${javaVersion}</source>
+                    <target>${javaVersion}</target>
+                </configuration>
+            </plugin>
             <!-- GWT Maven Plugin -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,145 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.realityforge.gwt.appcache.example</groupId>
+    <artifactId>gwt-appcache-example</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <!-- Convenience property to set the GWT version -->
+        <gwtVersion>2.7.0</gwtVersion>
+        <gwt.maven.plugin.version>2.7.0</gwt.maven.plugin.version>
+        <gwt.style>DETAILED</gwt.style>
+
+        <!-- GWT needs at least java 1.5 -->
+        <webappDirectory>${project.build.directory}/${project.build.finalName}</webappDirectory>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-servlet</artifactId>
+            <version>${gwtVersion}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-user</artifactId>
+            <version>${gwtVersion}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- needed for gwt integration tests-->
+        <dependency>
+            <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-dev</artifactId>
+            <version>${gwtVersion}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>org.apache.geronimo.specs</groupId>-->
+            <!--<artifactId>geronimo-servlet_3.0_spec</artifactId>-->
+            <!--<version>1.0</version>-->
+        <!--</dependency>-->
+        <!--<dependency>-->
+            <!--<groupId>com.google.code.findbugs</groupId>-->
+            <!--<artifactId>findbugs</artifactId>-->
+            <!--<version>2.0.1</version>-->
+        <!--</dependency>-->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.0.0.GA</version>
+            <type>jar</type>
+        </dependency>
+        <!--<dependency>-->
+            <!--<groupId>javax.validation</groupId>-->
+            <!--<artifactId>validation-api</artifactId>-->
+            <!--<version>1.0.0</version>-->
+            <!--<type>sources</type>-->
+        <!--</dependency>-->
+        <dependency>
+            <groupId>org.realityforge.gwt.cache-filter</groupId>
+            <artifactId>gwt-cache-filter</artifactId>
+            <version>0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.realityforge.gwt.appcache</groupId>
+            <artifactId>gwt-appcache-client</artifactId>
+            <version>1.0.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.realityforge.gwt.appcache</groupId>
+            <artifactId>gwt-appcache-linker</artifactId>
+            <version>1.0.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.realityforge.gwt.appcache</groupId>
+            <artifactId>gwt-appcache-server</artifactId>
+            <version>1.0.7</version>
+        </dependency>
+    </dependencies>
+<!--
+
+
+    # This dependency demonstrates that appcache can work even when caching disabled
+    # for the resources within the manifest. Firefox disallows no-store in Cache-control
+    # header.
+
+    gwt_appcache_client: org.realityforge.gwt.appcache:gwt-appcache-client:jar:1.0.5
+    gwt_appcache_linker: org.realityforge.gwt.appcache:gwt-appcache-linker:jar:1.0.5
+    gwt_appcache_server: org.realityforge.gwt.appcache:gwt-appcache-server:jar:1.0.5
+    -->
+    <build>
+        <plugins>
+            <!-- GWT Maven Plugin -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>gwt-maven-plugin</artifactId>
+                <version>${gwt.maven.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test</goal>
+                            <goal>generateAsync</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <!-- Plugin configuration. There are many available options, see
+                  gwt-maven-plugin documentation at codehaus.org -->
+                <configuration>
+                    <runTarget>index.html</runTarget>
+                    <hostedWebapp>${webappDirectory}</hostedWebapp>
+                    <mode>htmlunit</mode>
+                    <includes>**/Gwt*Suite.java</includes>
+                    <compileReport>true</compileReport>
+                    <style>${gwt.style}</style>
+                </configuration>
+            </plugin>
+
+            <!-- Copy static web files before executing gwt:run -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>2.1.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>exploded</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <webappDirectory>${webappDirectory}</webappDirectory>
+                    <packagingExcludes>WEB-INF/web.xml</packagingExcludes>
+                    <warSourceExcludes>web.xml</warSourceExcludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/org/realityforge/gwt/appcache/example/client/Example.java
+++ b/src/main/java/org/realityforge/gwt/appcache/example/client/Example.java
@@ -16,7 +16,6 @@ import com.google.gwt.user.client.ui.InlineHTML;
 import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextArea;
 import com.google.gwt.user.client.ui.VerticalPanel;
-import javax.annotation.Nonnull;
 import org.realityforge.gwt.appcache.client.ApplicationCache;
 import org.realityforge.gwt.appcache.client.event.CachedEvent;
 import org.realityforge.gwt.appcache.client.event.CachedEvent.Handler;
@@ -45,56 +44,56 @@ public final class Example
 
       cache.addCachedHandler( new Handler()
       {
-        @Override
-        public void onCachedEvent( @Nonnull final CachedEvent event )
+        
+        public void onCachedEvent(  final CachedEvent event )
         {
           appendText( textPanel, "Cached", "blue" );
         }
       } );
       cache.addCheckingHandler( new CheckingEvent.Handler()
       {
-        @Override
-        public void onCheckingEvent( @Nonnull final CheckingEvent event )
+        
+        public void onCheckingEvent(  final CheckingEvent event )
         {
           appendText( textPanel, "Checking", "yellow" );
         }
       } );
       cache.addDownloadingHandler( new DownloadingEvent.Handler()
       {
-        @Override
-        public void onDownloadingEvent( @Nonnull final DownloadingEvent event )
+        
+        public void onDownloadingEvent(  final DownloadingEvent event )
         {
           appendText( textPanel, "Downloading", "orange" );
         }
       } );
       cache.addErrorHandler( new ErrorEvent.Handler()
       {
-        @Override
-        public void onErrorEvent( @Nonnull final ErrorEvent event )
+        
+        public void onErrorEvent(  final ErrorEvent event )
         {
           appendText( textPanel, "Error", "red" );
         }
       } );
       cache.addNoUpdateHandler( new NoUpdateEvent.Handler()
       {
-        @Override
-        public void onNoUpdateEvent( @Nonnull final NoUpdateEvent event )
+        
+        public void onNoUpdateEvent(  final NoUpdateEvent event )
         {
           appendText( textPanel, "NoUpdate", "green" );
         }
       } );
       cache.addObsoleteHandler( new ObsoleteEvent.Handler()
       {
-        @Override
-        public void onObsoleteEvent( @Nonnull final ObsoleteEvent event )
+        
+        public void onObsoleteEvent(  final ObsoleteEvent event )
         {
           appendText( textPanel, "Obsolete", "yellow" );
         }
       } );
       cache.addProgressHandler( new ProgressEvent.Handler()
       {
-        @Override
-        public void onProgressEvent( @Nonnull final ProgressEvent event )
+        
+        public void onProgressEvent(  final ProgressEvent event )
         {
           if ( event.isLengthComputable() )
           {
@@ -108,8 +107,8 @@ public final class Example
       } );
       cache.addUpdateReadyHandler( new UpdateReadyEvent.Handler()
       {
-        @Override
-        public void onUpdateReadyEvent( @Nonnull final UpdateReadyEvent event )
+        
+        public void onUpdateReadyEvent(  final UpdateReadyEvent event )
         {
           appendText( textPanel, "UpdateReady", "green" );
         }
@@ -118,7 +117,7 @@ public final class Example
         final Button button = new Button( "Request cache update" );
         button.addClickHandler( new ClickHandler()
         {
-          @Override
+          
           public void onClick( final ClickEvent event )
           {
             cache.requestUpdate();
@@ -131,7 +130,7 @@ public final class Example
         final Button button = new Button( "Request removal of cache" );
         button.addClickHandler( new ClickHandler()
         {
-          @Override
+          
           public void onClick( final ClickEvent event )
           {
             cache.removeCache();
@@ -144,7 +143,7 @@ public final class Example
         final Button button = new Button( "Request cache swap" );
         button.addClickHandler( new ClickHandler()
         {
-          @Override
+          
           public void onClick( final ClickEvent event )
           {
             cache.swapCache();
@@ -156,7 +155,7 @@ public final class Example
         final Button button = new Button( "Abort cache download" );
         button.addClickHandler( new ClickHandler()
         {
-          @Override
+          
           public void onClick( final ClickEvent event )
           {
             cache.abort();
@@ -169,7 +168,7 @@ public final class Example
         final Button button = new Button( "Show image from cache" );
         button.addClickHandler( new ClickHandler()
         {
-          @Override
+          
           public void onClick( final ClickEvent event )
           {
             panel.add( new Image( GWT.getModuleBaseURL() + "bonsai tree.jpg" ) );
@@ -182,7 +181,7 @@ public final class Example
         final Button button = new Button( "Show time with fallback when offline" );
         button.addClickHandler( new ClickHandler()
         {
-          @Override
+          
           public void onClick( final ClickEvent event )
           {
             final RequestBuilder requestBuilder =
@@ -191,7 +190,7 @@ public final class Example
             {
               requestBuilder.sendRequest( "", new RequestCallback()
               {
-                @Override
+                
                 public void onResponseReceived( final Request request, final Response response )
                 {
                   final TextArea textArea = new TextArea();
@@ -199,7 +198,7 @@ public final class Example
                   panel.add( textArea );
                 }
 
-                @Override
+                
                 public void onError( final Request request, final Throwable exception )
                 {
                   final TextArea textArea = new TextArea();

--- a/src/main/java/org/realityforge/gwt/appcache/example/server/ManifestServlet.java
+++ b/src/main/java/org/realityforge/gwt/appcache/example/server/ManifestServlet.java
@@ -1,10 +1,10 @@
 package org.realityforge.gwt.appcache.example.server;
 
-import javax.servlet.annotation.WebServlet;
+//import javax.servlet.annotation.WebServlet;
 import org.realityforge.gwt.appcache.server.AbstractManifestServlet;
 import org.realityforge.gwt.appcache.server.propertyprovider.UserAgentPropertyProvider;
 
-@WebServlet(urlPatterns = { "/example.appcache" })
+//@WebServlet(urlPatterns = { "/example.appcache" })
 public class ManifestServlet
   extends AbstractManifestServlet
 {

--- a/src/main/java/org/realityforge/gwt/appcache/example/server/TimeServlet.java
+++ b/src/main/java/org/realityforge/gwt/appcache/example/server/TimeServlet.java
@@ -3,12 +3,12 @@ package org.realityforge.gwt.appcache.example.server;
 import java.io.IOException;
 import java.util.Date;
 import javax.servlet.ServletException;
-import javax.servlet.annotation.WebServlet;
+//import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-@WebServlet( urlPatterns = "/time" )
+//@WebServlet( urlPatterns = "/time" )
 public class TimeServlet
   extends HttpServlet
 {

--- a/src/main/java/org/realityforge/gwt/appcache/example/server/TimeServlet.java
+++ b/src/main/java/org/realityforge/gwt/appcache/example/server/TimeServlet.java
@@ -17,6 +17,6 @@ public class TimeServlet
     throws ServletException, IOException
   {
     response.setStatus( HttpServletResponse.SC_OK );
-    response.getOutputStream().write( new Date().toString().getBytes() );
+    response.getOutputStream().println(new Date().toString());
   }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -6,4 +6,14 @@
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>
   </welcome-file-list>
+
+
+    <servlet>
+        <servlet-name>manifestServlet</servlet-name>
+        <servlet-class>org.realityforge.gwt.appcache.example.server.ManifestServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>manifestServlet</servlet-name>
+        <url-pattern>/example.appcache</url-pattern>
+    </servlet-mapping>
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -6,14 +6,4 @@
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>
   </welcome-file-list>
-
-
-    <servlet>
-        <servlet-name>manifestServlet</servlet-name>
-        <servlet-class>org.realityforge.gwt.appcache.example.server.ManifestServlet</servlet-class>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>manifestServlet</servlet-name>
-        <url-pattern>/example.appcache</url-pattern>
-    </servlet-mapping>
 </web-app>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -6,4 +6,25 @@
   <welcome-file-list>
     <welcome-file>index.html</welcome-file>
   </welcome-file-list>
+
+
+    <servlet>
+        <servlet-name>manifestServlet</servlet-name>
+        <servlet-class>org.realityforge.gwt.appcache.example.server.ManifestServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>manifestServlet</servlet-name>
+        <url-pattern>/example.appcache</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>timeServlet</servlet-name>
+        <servlet-class>org.realityforge.gwt.appcache.example.server.TimeServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>timeServlet</servlet-name>
+        <url-pattern>/time</url-pattern>
+    </servlet-mapping>
+
+
 </web-app>


### PR DESCRIPTION
Having migrated to latest version of gwt 2.7.0, maven, and added support for tomcat 6 (ie servlet 3.0 dependency is removed), this example works fine when deployed directly to tomcat6/7. 

However, I am unable to get the example working in Dev Mode or Super Dev Mode in IntelliJ, I see the following exception on deployment:

```
WARNING: Error generating response for manifest
javax.servlet.ServletException: can not read permutation information
    at org.realityforge.gwt.appcache.server.AbstractManifestServlet.selectPermutations(AbstractManifestServlet.java:483)
    at org.realityforge.gwt.appcache.server.AbstractManifestServlet.doGet(AbstractManifestServlet.java:117)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:617)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:723)
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:290)
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:206)
    at org.apache.catalina.core.StandardWrapperValve.invoke(StandardWrapperValve.java:233)
    at org.apache.catalina.core.StandardContextValve.invoke(StandardContextValve.java:191)
    at org.apache.catalina.core.StandardHostValve.invoke(StandardHostValve.java:127)
    at org.apache.catalina.valves.ErrorReportValve.invoke(ErrorReportValve.java:103)
    at org.apache.catalina.core.StandardEngineValve.invoke(StandardEngineValve.java:109)
    at org.apache.catalina.connector.CoyoteAdapter.service(CoyoteAdapter.java:293)
    at org.apache.coyote.http11.Http11Processor.process(Http11Processor.java:861)
    at org.apache.coyote.http11.Http11Protocol$Http11ConnectionHandler.process(Http11Protocol.java:606)
    at org.apache.tomcat.util.net.JIoEndpoint$Worker.run(JIoEndpoint.java:489)
    at java.lang.Thread.run(Thread.java:695)
Caused by: javax.servlet.ServletException: Unable to locate permutations file: /example/permutations.xml
    at org.realityforge.gwt.appcache.server.AbstractManifestServlet.getPermutationDescriptors(AbstractManifestServlet.java:504)
    at org.realityforge.gwt.appcache.server.AbstractManifestServlet.selectPermutations(AbstractManifestServlet.java:435)
    ... 15 more
```

Is gwt 2.7.0 supported, perhaps permutations.xml is no longer generated?

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/realityforge/gwt-appcache-example/1)

<!-- Reviewable:end -->
